### PR TITLE
Fix the footer so it doesn't stick out like a sore thumb.

### DIFF
--- a/source/_views/partials/footer.html
+++ b/source/_views/partials/footer.html
@@ -1,6 +1,10 @@
-<footer class="container">
-    &copy; {{ "now"|date("Y") }} {{ site.title }}
-</footer>
+<div class="row centered-text">
+    <div class="small-12 columns">
+        <footer class="container">
+            &copy; {{ "now"|date("Y") }} {{ site.title }}
+        </footer>
+    </div>
+</div>
 
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="{{ site.url }}/components/jquery/jquery.min.js"><\/script>')</script>


### PR DESCRIPTION
Just uses the Foundation container, and centers the copyright. Simple, but looks much less "thrown together at the last second" in my opinion.
