### PR TITLE
changed the meetings page to list the meetings type instead of the posts...

### DIFF
--- a/source/meetings.html
+++ b/source/meetings.html
@@ -2,7 +2,9 @@
 layout: page
 title: Meetings
 generator: pagination
-use:
+pagination:
+    provider: data.meetings
+use: 
 - meetings
 
 ---


### PR DESCRIPTION
Small change, big consequences. I switched the meetings page to list meetings instead of posts. This gets rid of the old meetings (which are actually "posts") and now shows the new ones.